### PR TITLE
Add "--process" option to override searched for process

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,34 @@ ww only works in KDE. It works in X11 and Wayland.
 
 if you want to raise or jump to an open firefox window:
 
-`ww -f firefox -c firefox`
+```bash
+ww -f firefox -c firefox
+```
 
 if you want to raise or jump to an app with an specific class:
 
-`ww -f kitty.terminal -c 'kitty --class kitty.terminal'`
+```bash
+ww -f kitty.terminal -c 'kitty --class kitty.terminal'
+```
 
 Note: In this example `kitty` allows you to pass the `class` option that sets the window class.
 This is a kitty feature, not a ww feature.
 
 If you want to raise any window that matches a title. JS regexp allowed:
 
-`ww -fa 'Zoom meeting'`
+```bash
+ww -fa 'Zoom meeting'
+```
+
+Sometimes the command to start a program only indirectly runs the actual
+program, making it not directly findable, such as when using flatpaks. Then you
+can use `-p` to separate the string used when searching for the application:
+```bash
+ww -f steam -p steam -c 'flatpak run --branch=stable --arch=x86_64 --command=/app/bin/steam --file-forwarding com.valvesoftware.Steam'
+```
+
+(The value specified to `-p` is directly passed along to `pgrep`, see "How does
+it work?" below.)
 
 ## Paramaters:
 ```
@@ -38,6 +54,7 @@ If you want to raise any window that matches a title. JS regexp allowed:
 -f  --filter              filter by window class
 -fa --filter-alternative  filter by window title (caption)
 -c  --command             command to check if running and run if no process is found
+-p  --process             overide the process name used when checking if running, defaults to --command
 ```
 
 # Create shortcuts
@@ -53,7 +70,7 @@ Internally ww uses 2 main things to work: `pgrep` and "on demand" KWin scripts.
 
 When you run, for example `ww -f firefox c -firefox`, ww tries to find a process running with the exact command:
 
-`pgrep -o -f firefox`
+`pgrep -o -a -f firefox`
 
 This detects if the application is running or not.
 

--- a/ww
+++ b/ww
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Usage: ww -f "window class filter" -c "run if not found"
-# Usage: ww -fa "window title filter" -c "run if not found"
+# Usage: ww -f "window class filter" -c "run if not found" [-p "process name"]
+# Usage: ww -fa "window title filter" -c "run if not found" [-p "process name"]
 
 TOGGLE="false"
 POSITIONAL=()
@@ -10,6 +10,11 @@ while [[ $# -gt 0 ]]; do
 	case $key in
 	-c | --command)
 		COMMAND="$2"
+		shift # past argument
+		shift # past value
+		;;
+	-p | --process)
+		PROCESS="$2"
 		shift # past argument
 		shift # past value
 		;;
@@ -39,6 +44,10 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
+if [ -z "$PROCESS" ]; then
+	PROCESS=$COMMAND
+fi
+
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
 if [ -n "$HELP" ]; then
@@ -52,6 +61,7 @@ Paramaters:
 -fa --filter-alternative  filter by window title (caption)
 -t  --toggle              also minimize the window if it is already active
 -c  --command             command to check if running and run if no process is found
+-p  --process             overide the process name used when checking if running, defaults to --command
 EOF
 	exit 0
 fi
@@ -106,7 +116,7 @@ if [ -z "$FILTERBY" ] && [ -z "$FILTERALT" ]; then
 	exit 1
 fi
 
-IS_RUNNING=$(pgrep -o -a -f "$COMMAND" | grep -v "$CURRENT_SCRIPT_NAME")
+IS_RUNNING=$(pgrep -o -a -f "$PROCESS" | grep -v "$CURRENT_SCRIPT_NAME")
 
 if [ -n "$IS_RUNNING" ] || [ -n "$FILTERALT" ]; then
 

--- a/ww_kde6
+++ b/ww_kde6
@@ -123,16 +123,16 @@ if [ -n "$IS_RUNNING" ] || [ -n "$FILTERALT" ]; then
 	ensure_script "$FILTERBY" "$FILTERALT" "$TOGGLE"
 
 	# install the script
-	ID=$(dbus-send --print-reply --dest=org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "string:$SCRIPT_PATH" "string:$SCRIPT_NAME" | awk 'END {print $2}')
+	ID=$(dbus-send --session --print-reply --dest=org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "string:$SCRIPT_PATH" "string:$SCRIPT_NAME" | awk 'END {print $2}')
 	# run the script
-	dbus-send --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Script.run >/dev/null 2>&1
-	dbus-send --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Scripting.run >/dev/null 2>&1
+	dbus-send --session --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Script.run >/dev/null 2>&1
+	dbus-send --session --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Scripting.run >/dev/null 2>&1
 	# stop the script
-	dbus-send --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Script.stop >/dev/null 2>&1
-	dbus-send --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Scripting.stop >/dev/null 2>&1
+	dbus-send --session --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Script.stop >/dev/null 2>&1
+	dbus-send --session --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Scripting.stop >/dev/null 2>&1
 
 	# uninstall the script
-	dbus-send --print-reply --dest=org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "string:$SCRIPT_NAME" >/dev/null 2>&1
+	dbus-send --session --print-reply --dest=org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "string:$SCRIPT_NAME" >/dev/null 2>&1
 elif [ -n "$COMMAND" ]; then
 	$COMMAND &
 fi

--- a/ww_kde6
+++ b/ww_kde6
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Usage: ww -f "window class filter" -c "run if not found"
-# Usage: ww -fa "window title filter" -c "run if not found"
+# Usage: ww -f "window class filter" -c "run if not found" [-p "process name"]
+# Usage: ww -fa "window title filter" -c "run if not found" [-p "process name"]
 
 TOGGLE="false"
 POSITIONAL=()
@@ -10,6 +10,11 @@ while [[ $# -gt 0 ]]; do
 	case $key in
 	-c | --command)
 		COMMAND="$2"
+		shift # past argument
+		shift # past value
+		;;
+	-p | --process)
+		PROCESS="$2"
 		shift # past argument
 		shift # past value
 		;;
@@ -41,6 +46,10 @@ done
 
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
+if [ -z "$PROCESS" ]; then
+	PROCESS=$COMMAND
+fi
+
 if [ -n "$HELP" ]; then
 	cat <<EOF
 ww. Utility to raise or jump an applications in KDE. It interacts with KWin using KWin scripts and it is compatible with X11 and Wayland
@@ -52,6 +61,7 @@ Paramaters:
 -fa --filter-alternative  filter by window title (caption)
 -t  --toggle              also minimize the window if it is already active
 -c  --command             command to check if running and run if no process is found
+-p  --process             overide the process name used when checking if running, defaults to --command
 EOF
 	exit 0
 fi
@@ -106,7 +116,7 @@ if [ -z "$FILTERBY" ] && [ -z "$FILTERALT" ]; then
 	exit 1
 fi
 
-IS_RUNNING=$(pgrep -o -a -f "$COMMAND" | grep -v "$CURRENT_SCRIPT_NAME")
+IS_RUNNING=$(pgrep -o -a -f "$PROCESS" | grep -v "$CURRENT_SCRIPT_NAME")
 
 if [ -n "$IS_RUNNING" ] || [ -n "$FILTERALT" ]; then
 	

--- a/ww_kde6
+++ b/ww_kde6
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Usage: ww -f "window class filter" -c "run if not found"
+# Usage: ww -fa "window title filter" -c "run if not found"
+
+TOGGLE="false"
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+	key="$1"
+
+	case $key in
+	-c | --command)
+		COMMAND="$2"
+		shift # past argument
+		shift # past value
+		;;
+	-f | --filter)
+		FILTERBY="$2"
+		shift # past argument
+		shift # past value
+		;;
+	-fa | --filter-alternative)
+		FILTERALT="$2"
+		shift # past argument
+		shift # past value
+		;;
+	-t | --toggle)
+		TOGGLE="true"
+		shift # past argument
+		;;
+	-h | --help)
+		HELP="1"
+		shift # past argument
+		shift # past value
+		;;
+	*)                  # unknown option
+		POSITIONAL+=("$1") # save it in an array for later
+		shift              # past argument
+		;;
+	esac
+done
+
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [ -n "$HELP" ]; then
+	cat <<EOF
+ww. Utility to raise or jump an applications in KDE. It interacts with KWin using KWin scripts and it is compatible with X11 and Wayland
+
+Paramaters:
+
+-h  --help                show this help
+-f  --filter              filter by window class
+-fa --filter-alternative  filter by window title (caption)
+-t  --toggle              also minimize the window if it is already active
+-c  --command             command to check if running and run if no process is found
+EOF
+	exit 0
+fi
+
+SCRIPT_TEMPLATE=$(
+	cat <<EOF
+function kwinactivateclient(clientClass, clientCaption, toggle) {
+    var clients = workspace.windowList();
+    var compareToCaption = new RegExp(clientCaption || '', 'i');
+    var compareToClass = clientClass;
+    var isCompareToClass = clientClass.length > 0
+    for (var i = 0; i < clients.length; i++) {
+        var client = clients[i];
+        var classCompare = (isCompareToClass && client.resourceClass == compareToClass)
+        var captionCompare = (!isCompareToClass && compareToCaption.exec(client.caption))
+        if (classCompare || captionCompare) {
+            if (workspace.activeWindow != client) {
+                workspace.activeWindow = client;
+            } else if (toggle) {
+                client.minimized = true;
+            }
+            break;
+        }
+    }
+}
+kwinactivateclient('CLASS_NAME', 'CAPTION_NAME', TOGGLE);
+EOF
+)
+
+CURRENT_SCRIPT_NAME=$(basename "$0")
+
+# ensure the script file exists
+function ensure_script {
+	if [ ! -f SCRIPT_PATH ]; then
+		if [ ! -d "$SCRIPT_FOLDER" ]; then
+			mkdir -p "$SCRIPT_FOLDER"
+		fi
+		SCRIPT_CONTENT=${SCRIPT_TEMPLATE/CLASS_NAME/$1}
+		SCRIPT_CONTENT=${SCRIPT_CONTENT/CAPTION_NAME/$2}
+        SCRIPT_CONTENT=${SCRIPT_CONTENT/TOGGLE/$3}
+		#if [ "$1" == "class" ]; then
+		#SCRIPT_CONTENT=${SCRIPT_CLASS_NAME/REPLACE_ME/$2}
+		#else
+		#SCRIPT_CONTENT=${SCRIPT_CAPTION/REPLACE_ME/$2}
+		#fi
+		echo "$SCRIPT_CONTENT" >"$SCRIPT_PATH"
+	fi
+}
+
+if [ -z "$FILTERBY" ] && [ -z "$FILTERALT" ]; then
+	echo You need to specify a window filter. Either by class -f or by title -fa
+	exit 1
+fi
+
+IS_RUNNING=$(pgrep -o -a -f "$COMMAND" | grep -v "$CURRENT_SCRIPT_NAME")
+
+if [ -n "$IS_RUNNING" ] || [ -n "$FILTERALT" ]; then
+	
+	# trying for XDG_CONFIG_HOME first
+	SCRIPT_FOLDER_ROOT=$XDG_CONFIG_HOME
+	if [[ -z $SCRIPT_FOLDER_ROOT ]]; then
+		# fallback to the home folder
+		SCRIPT_FOLDER_ROOT=$HOME
+	fi
+
+	SCRIPT_FOLDER="$SCRIPT_FOLDER_ROOT/.wwscripts/"
+	SCRIPT_NAME=$(echo "$FILTERBY$FILTERALT" | md5sum | head -c 32)
+	SCRIPT_PATH="$SCRIPT_FOLDER$SCRIPT_NAME"
+	ensure_script "$FILTERBY" "$FILTERALT" "$TOGGLE"
+
+	# install the script
+	ID=$(dbus-send --print-reply --dest=org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "string:$SCRIPT_PATH" "string:$SCRIPT_NAME" | awk 'END {print $2}')
+	# run the script
+	dbus-send --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Script.run >/dev/null 2>&1
+	dbus-send --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Scripting.run >/dev/null 2>&1
+	# stop the script
+	dbus-send --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Script.stop >/dev/null 2>&1
+	dbus-send --print-reply --dest=org.kde.KWin /Scripting/Script$ID org.kde.kwin.Scripting.stop >/dev/null 2>&1
+
+	# uninstall the script
+	dbus-send --print-reply --dest=org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "string:$SCRIPT_NAME" >/dev/null 2>&1
+elif [ -n "$COMMAND" ]; then
+	$COMMAND &
+fi


### PR DESCRIPTION
Adds an option that lets you separate the searched for process name from the command. This is to support commands which start another process, meaning that you can't find the original command using `pgrep`, like when using flatpaks.

This is based on the fork from https://github.com/academo/ww-run-raise/pull/8, so you should probably merge that before merging this.

BTW, feel free to completely change anything in this PR if any implementation details don't suit you, I just quickly threw this together in an afternoon. :)
