### PR TITLE
support multiple users

### DIFF
--- a/ww
+++ b/ww
@@ -106,7 +106,9 @@ if [ -z "$FILTERBY" ] && [ -z "$FILTERALT" ]; then
 	exit 1
 fi
 
-IS_RUNNING=$(pgrep -u "$(whoami)" -o -a -f "$COMMAND" | grep -v "$CURRENT_SCRIPT_NAME")
+session_id=$(loginctl show-seat seat0 -p ActiveSession --value)
+user_id=$(loginctl show-session "$session_id" -p User --value)
+IS_RUNNING=$(pgrep -u "$user_id" -o -a -f "$COMMAND" | grep -v "$CURRENT_SCRIPT_NAME")
 
 if [ -n "$IS_RUNNING" ] || [ -n "$FILTERALT" ]; then
 

--- a/ww
+++ b/ww
@@ -106,7 +106,7 @@ if [ -z "$FILTERBY" ] && [ -z "$FILTERALT" ]; then
 	exit 1
 fi
 
-IS_RUNNING=$(pgrep -o -a -f "$COMMAND" | grep -v "$CURRENT_SCRIPT_NAME")
+IS_RUNNING=$(pgrep -u "$(whoami)" -o -a -f "$COMMAND" | grep -v "$CURRENT_SCRIPT_NAME")
 
 if [ -n "$IS_RUNNING" ] || [ -n "$FILTERALT" ]; then
 


### PR DESCRIPTION
Programs running in other sessions can interfere with the detection of open programs.

This PR fixes this by making pgrep only consider programs running for a specific user