### PR TITLE
Avoid that pgrep detects the present script

### DIFF
--- a/ww
+++ b/ww
@@ -187,7 +187,7 @@ fi
 
 # Note: In this case, `$USER_FILTER` must not have quotes around it.
 # shellcheck disable=SC2086
-IS_RUNNING=$(pgrep $USER_FILTER -o -a -f "$PROCESS")
+IS_RUNNING=$(pgrep $USER_FILTER -o -a -f "$PROCESS" --ignore-ancestors)
 
 if [[ -n "$IS_RUNNING" || -n "$FILTERALT" ]]; then
 	# trying for XDG_CONFIG_HOME first.


### PR DESCRIPTION
Use the `--ignore-ancestors` parameter of `pgrep` to try to avoid "false positives" like when the user executes (when no instance of Krusader is being running):
    `./ww -fa krusader -c krusader`
but failing (Krusader is not being executed) because the `IS_RUNNING` variable is equal to e.g. `5604 /bin/bash ./ww -fa krusader -c krusader`. Problems like this one were tried to be prevented previously with the `| grep -v "$CURRENT_SCRIPT_NAME"` code that was removed recently, the `--ignore-ancestors` parameter is aimed to avoid the detection of the `ww` process (because that process is an "ancestor" of the `pgrep` process).