### PR TITLE
Fix running kwin script depending on kwin version

### DIFF
--- a/ww
+++ b/ww
@@ -227,21 +227,21 @@ if [[ -n "$IS_RUNNING" || -n "$FILTERALT" ]]; then
 	kwinVersion=$(kwin --version | cut -d ' ' -f2)
 
 	if ver_between 5.21.90 "$kwinVersion" 5.27.79; then
-		SCRIPT_RUN_PATH=org.kde.kwin.Script.run
+		SCRIPT_API_PATH=org.kde.kwin.Script
 		SCRIPT_PATH="/$ID"
 	elif ver_lt 5.27.80 "$kwinVersion"; then
-		SCRIPT_RUN_PATH=org.kde.kwin.Script.run
+		SCRIPT_API_PATH=org.kde.kwin.Script
 		SCRIPT_PATH="/Scripting/Script$ID"
 	else
-		SCRIPT_RUN_PATH=org.kde.kwin.Scripting.run
+		SCRIPT_API_PATH=org.kde.kwin.Scripting
 		SCRIPT_PATH="/$ID"
 	fi
 
 	# Run using detected pat
-	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" $SCRIPT_RUN_PATH >/dev/null 2>&1
+	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" $SCRIPT_API_PATH.run >/dev/null 2>&1
 
 	# Stop using same path
-	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" $SCRIPT_RUN_PATH >/dev/null 2>&1
+	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" $SCRIPT_API_PATH.stop >/dev/null 2>&1
 
 elif [[ -n "$COMMAND" ]]; then
 	$COMMAND &

--- a/ww
+++ b/ww
@@ -170,6 +170,17 @@ function ensure_script {
 	fi
 }
 
+# Check if a version string is between two inclusive versions.
+function ver_between() {
+    # args: min, actual, max
+    printf '%s\n' "$@" | sort -C -V
+}
+
+# Check if a version string is lower than another.
+function ver_lt() {
+    printf '%s\n' "$1" "$2" | sort -C -V
+}
+
 if [[ -z "$FILTERBY" && -z "$FILTERALT" ]]; then
 	echo "If you want that this program find a window, you need to specify a window filter — either by class (\`-f\`) or by title (\`-fa\`). More information can be seen if this script is called using the \`--help\` parameter."
 	exit 1
@@ -211,20 +222,26 @@ if [[ -n "$IS_RUNNING" || -n "$FILTERALT" ]]; then
 	# Uses `awk` separately in order to avoid masking a return value, as Shellcheck recommends
 	ID=$(awk '{print $2}' <<< "$INFO_DBUS_SEND") || exit 1
 
-	# Try legacy first (kde <= 5) and then new (kde >= 6)
-	if dbus-send --session --dest=org.kde.KWin --print-reply=literal "/$ID" org.kde.kwin.Scripting.run 2>/dev/null; then
-    	SCRIPT_PATH="/$ID"
+	# Use kwin version to decide how to call the script run api which changes between kwin versions.
+	# See https://github.com/academo/ww-run-raise/issues/15#issuecomment-2632214974 for more info.
+	kwinVersion=$(kwin --version | cut -d ' ' -f2)
+
+	if ver_between 5.21.90 "$kwinVersion" 5.27.79; then
+		SCRIPT_RUN_PATH=org.kde.kwin.Script.run
+		SCRIPT_PATH="/$ID"
+	elif ver_lt 5.27.80 "$kwinVersion"; then
+		SCRIPT_RUN_PATH=org.kde.kwin.Script.run
+		SCRIPT_PATH="/Scripting/Script$ID"
 	else
-    	SCRIPT_PATH="/Scripting/Script$ID"
+		SCRIPT_RUN_PATH=org.kde.kwin.Scripting.run
+		SCRIPT_PATH="/$ID"
 	fi
 
-	# Run using detected path
-	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" org.kde.kwin.Scripting.run >/dev/null 2>&1
-	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" org.kde.kwin.Script.run >/dev/null 2>&1
+	# Run using detected pat
+	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" $SCRIPT_RUN_PATH >/dev/null 2>&1
 
 	# Stop using same path
-	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" org.kde.kwin.Scripting.stop >/dev/null 2>&1
-	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" org.kde.kwin.Script.stop >/dev/null 2>&1
+	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" $SCRIPT_RUN_PATH >/dev/null 2>&1
 
 elif [[ -n "$COMMAND" ]]; then
 	$COMMAND &

--- a/ww
+++ b/ww
@@ -77,9 +77,14 @@ EOF
 	exit 0
 fi
 
-if [[ -n "$INFO_ACTIVE" ]]; then
+function get_kwin_version() {
     kwinSupportInfo="$(qdbus org.kde.KWin /KWin supportInformation)" || exit 1
     kwinVersion="$(awk '/KWin version:/ {print $3}' <<< "$kwinSupportInfo")" || exit 1
+    echo "$kwinVersion"
+}
+
+if [[ -n "$INFO_ACTIVE" ]]; then
+    kwinVersion=$(get_kwin_version)
     kwinMajorVersion="$(awk -F"." '{print $1}' <<< "$kwinVersion")" || exit 1    
     # This feature needs at least this KWin version
     readonly minimumVersion=6 || exit 1
@@ -224,7 +229,7 @@ if [[ -n "$IS_RUNNING" || -n "$FILTERALT" ]]; then
 
 	# Use kwin version to decide how to call the script run api which changes between kwin versions.
 	# See https://github.com/academo/ww-run-raise/issues/15#issuecomment-2632214974 for more info.
-	kwinVersion=$(kwin --version | cut -d ' ' -f2)
+	kwinVersion=$(get_kwin_version)
 
 	if ver_between 5.21.90 "$kwinVersion" 5.27.79; then
 		SCRIPT_API_PATH=org.kde.kwin.Script
@@ -238,10 +243,10 @@ if [[ -n "$IS_RUNNING" || -n "$FILTERALT" ]]; then
 	fi
 
 	# Run using detected pat
-	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" $SCRIPT_API_PATH.run >/dev/null 2>&1
+	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" ${SCRIPT_API_PATH}.run >/dev/null 2>&1
 
 	# Stop using same path
-	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" $SCRIPT_API_PATH.stop >/dev/null 2>&1
+	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" ${SCRIPT_API_PATH}.stop >/dev/null 2>&1
 
 elif [[ -n "$COMMAND" ]]; then
 	$COMMAND &


### PR DESCRIPTION
This PR fixes issue #15 

There are three historical ways to call the org.kde.kwin.Script.run API aka org.kde.kwin.Scripting.run and some kwin versions exist that did not export that method at all.

These are the 3 ways to call this API from oldest to newest:
1. org.kde.kwin.Scripting.run with script ids in /$ID
    Introduced 23rd of December 2013 with [ab253cd1](https://invent.kde.org/plasma/kwin/-/commit/ab253cd17856d63ccfbc689f8d0515f03ae8e45b) 
    Part of kwin 4.96.0
    I do not know when it broke.
2. org.kde.kwin.Script.run with script ids in /$ID
    Part of kwin [5.21.90 - 5.27.80) between 4th of March 2021 and 26th of May 2023 [1]
3. org.kde.kwin.Script.run with script ids in /Scripting/Script$ID 
    Part of kwin >= 5.27.80 since 26th of May 2023 [2]

[1] [0eb37563](https://invent.kde.org/plasma/kwin/-/commit/0eb37563e93d35dda9965e964c2304b7ce33675e) Added back the export of org.kde.kwin.Scripting.run
[2] [982e4093](https://invent.kde.org/plasma/kwin/-/commit/982e409319fb43113ed9a71f043beaee66882e39) Changed the namespace for the script ids to /Scripting/Script$ID