### PR TITLE
Drop dependency on qdbus for run-or-raise functionality

### DIFF
--- a/ww
+++ b/ww
@@ -77,8 +77,12 @@ EOF
 	exit 0
 fi
 
+dbus_kwin () {
+    dbus-send --session --dest=org.kde.KWin --print-reply=literal "$@"
+}
+
 function get_kwin_version() {
-    kwinSupportInfo="$(qdbus org.kde.KWin /KWin supportInformation)" || exit 1
+    kwinSupportInfo="$(dbus_kwin /KWin org.kde.KWin.supportInformation)" || exit 1
     kwinVersion="$(awk '/KWin version:/ {print $3}' <<< "$kwinSupportInfo")" || exit 1
     echo "$kwinVersion"
 }
@@ -97,17 +101,18 @@ if [[ -n "$INFO_ACTIVE" ]]; then
     jsFile="$(mktemp)" || exit 1   # It is the file where the javascript code is going to be saved
     echo "print(\"$jsFile\",workspace.activeWindow.internalId);" > "$jsFile" || exit 1
     
-    scriptId="$(qdbus org.kde.KWin /Scripting loadScript "$jsFile")" || exit 1
+    scriptId_response="$(dbus_kwin /Scripting org.kde.kwin.Scripting.loadScript "string:$jsFile")" || exit 1
+    scriptId=$(awk '{print $2}' <<< "$scriptId_response") || exit 1
     timestamp="$(date +"%Y-%m-%d %H:%M:%S")" || exit 1
     # Starts the script
-    qdbus org.kde.KWin /Scripting/Script"$scriptId" run || exit 1
+    dbus_kwin "/Scripting/Script$scriptId" org.kde.kwin.Script.run || exit 1
     
     # Uses some arguments that are also seen on https://github.com/jinliu/kdotool/blob/master/src/main.rs
     outputJournalctl="$(journalctl --since "$timestamp" --user --user-unit=plasma-kwin_wayland.service --user-unit=plasma-kwin_x11.service --output=cat -g "js: $jsFile")" || exit 1
     # Uses `awk` separately in order to avoid masking a return value, as Shellcheck recommends
     windowId="$(awk '{print $3}' <<< "$outputJournalctl")" || exit 1
     # Stops the script
-    qdbus org.kde.KWin /Scripting/Script"$scriptId" stop || exit 1
+    dbus_kwin "/Scripting/Script$scriptId" org.kde.kwin.Script.stop || exit 1
     
     # Shows the information about that window
     qdbus org.kde.KWin /KWin org.kde.KWin.getWindowInfo "$windowId" || exit 1
@@ -223,7 +228,7 @@ if [[ -n "$IS_RUNNING" || -n "$FILTERALT" ]]; then
 
 	SCRIPT_NAME="ww$RANDOM"
 
-	INFO_DBUS_SEND=$(dbus-send --session --dest=org.kde.KWin --print-reply=literal /Scripting org.kde.kwin.Scripting.loadScript "string:$SCRIPT_PATH" "string:$SCRIPT_NAME") || exit 1
+	INFO_DBUS_SEND=$(dbus_kwin /Scripting org.kde.kwin.Scripting.loadScript "string:$SCRIPT_PATH" "string:$SCRIPT_NAME") || exit 1
 	# Uses `awk` separately in order to avoid masking a return value, as Shellcheck recommends
 	ID=$(awk '{print $2}' <<< "$INFO_DBUS_SEND") || exit 1
 
@@ -243,10 +248,10 @@ if [[ -n "$IS_RUNNING" || -n "$FILTERALT" ]]; then
 	fi
 
 	# Run using detected pat
-	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" ${SCRIPT_API_PATH}.run >/dev/null 2>&1
+	dbus_kwin "$SCRIPT_PATH" ${SCRIPT_API_PATH}.run >/dev/null 2>&1
 
 	# Stop using same path
-	dbus-send --session --dest=org.kde.KWin --print-reply=literal "$SCRIPT_PATH" ${SCRIPT_API_PATH}.stop >/dev/null 2>&1
+	dbus_kwin "$SCRIPT_PATH" ${SCRIPT_API_PATH}.stop >/dev/null 2>&1
 
 elif [[ -n "$COMMAND" ]]; then
 	$COMMAND &

--- a/ww
+++ b/ww
@@ -114,8 +114,18 @@ if [[ -n "$INFO_ACTIVE" ]]; then
     # Stops the script
     dbus_kwin "/Scripting/Script$scriptId" org.kde.kwin.Script.stop || exit 1
     
+    if command -v qdbus 2>&1 >/dev/null; then
+        qdbus_bin=qdbus
+    elif command -v qdbus6 2>&1 >/dev/null; then
+        # On Arch some users might only have qt6-tools installed
+        qdbus_bin=qdbus6
+    else
+        echo "'qdbus' or 'qdbus6' command not found, aborting."
+        exit 1
+    fi
+
     # Shows the information about that window
-    qdbus org.kde.KWin /KWin org.kde.KWin.getWindowInfo "$windowId" || exit 1
+    $qdbus_bin org.kde.KWin /KWin org.kde.KWin.getWindowInfo "$windowId" || exit 1
     
     exit 0
 fi


### PR DESCRIPTION
On my Arch system `qdbus` is not in PATH because I have only `qt6-tools` installed which puts qdbus in `/usr/lib/qt6/bin/`. `qt5-tools` would provide it in `/usr/bin/` but I don't use any software that pulls it in.

For people with a similar setup `ww` does not work out of the box. This patch fixes it for the run-or-raise codepath.

I did not remove the last qdbus dependency in `-ia` mode because the output format would change from
```
activities: e95f6959-43e3-4e95-a42b-3ce622137856
caption: ww-run-raise : bash — Konsole
clientMachine: localhost
desktopFile: org.kde.konsole
desktops: 8530ccdc-c6aa-4c2f-a76f-9dcd890f89a6
fullscreen: false
...
```
to 
```
method return time=1745072712.820071 sender=:1.13 -> destination=:1.188 serial=1168 reply_serial=2
   array [
      dict entry(
         string "activities"
         variant             array [
               string "e95f6959-43e3-4e95-a42b-3ce622137856"
            ]
      )
      dict entry(
         string "caption"
         variant             string "ww-run-raise : bash — Konsole"
      )
      dict entry(
         string "clientMachine"
         variant             string "localhost"
      )
      dict entry(
         string "desktopFile"
         variant             string "org.kde.konsole"
      )
```

Also,
- `--session` is the default for dbus-send, remove
- .run and .stop do not output anything for me, remove useless redirects