### PR TITLE
use `/usr/bin/env bash`

### DIFF
--- a/ww
+++ b/ww
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TOGGLE="false"
 POSITIONAL=()


### PR DESCRIPTION
It’s better to use #!/usr/bin/env bash instead of #!/bin/bash, because some systems (like NixOS) might not have Bash in /bin.

https://askubuntu.com/a/1402721