### PR TITLE
Update logic when using -fa flag

### DIFF
--- a/ww
+++ b/ww
@@ -219,7 +219,7 @@ fi
 # shellcheck disable=SC2086
 IS_RUNNING=$(pgrep $USER_FILTER -o -a -f "$PROCESS" --ignore-ancestors)
 
-if [[ -n "$IS_RUNNING" || -n "$FILTERALT" ]]; then
+if [[ -n "$IS_RUNNING" ]]; then
 	# trying for XDG_CONFIG_HOME first.
 	# shellcheck disable=SC2154
 	SCRIPT_FOLDER_ROOT=$XDG_CONFIG_HOME


### PR DESCRIPTION
The condition removed here prevents the alternate command from running when using `-fa`.

This condition is part of the initial commit for this project, but I can't see any reason why there would be this fundamental behaviour difference between `-f` and `-fa`.

Behaviour _before_ this proposed change:

`ww -f example -c example` - `example` command is run if not already running, activates if already running
`ww -fa Example -c example` - `example` is never run, activates if already running

Behaviour _after_ this proposed change:

`ww -f example -c example` - `example` command is run if not already running, activates if already running
`ww -fa Example -c example` - `example` command is run if not already running, activates if already running