### PR TITLE
Fixed Google Chrome detection

### DIFF
--- a/ww
+++ b/ww
@@ -2,6 +2,7 @@
 
 TOGGLE="false"
 QUERY="false"
+SKIP_PROCESS_DETECTION="false"
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
 	key="$1"
@@ -20,6 +21,10 @@ while [[ $# -gt 0 ]]; do
 		FILTERBY="$2"
 		shift # past argument
 		shift # past value
+		;;
+	-P | --skip-process-detection)
+		SKIP_PROCESS_DETECTION="true"
+		shift # past argument
 		;;
 	-p | --process)
 		PROCESS="$2"
@@ -147,6 +152,8 @@ if [[ -n "$INFO_ACTIVE" ]]; then
     exit 0
 fi
 
+RESULT_ID=ww-result-$RANDOM
+
 SCRIPT_TEMPLATE=$(
 	cat <<EOF
 function kwinactivateclient(clientClass, clientCaption, clientClassRegex, toggle) {
@@ -168,6 +175,8 @@ function kwinactivateclient(clientClass, clientCaption, clientClassRegex, toggle
             matchingClients.push(client);
         }
     }
+
+    print('$RESULT_ID: result=' + matchingClients.length);
 
     if (matchingClients.length === 1) {
         var client = matchingClients[0];
@@ -253,9 +262,13 @@ if [[ -n "$CURRENTUSERONLY" ]] && command -v loginctl >/dev/null 2>&1; then
 	fi
 fi
 
-# Note: In this case, `$USER_FILTER` must not have quotes around it.
-# shellcheck disable=SC2086
-IS_RUNNING=$(pgrep $USER_FILTER -o -a -f "$PROCESS" --ignore-ancestors)
+if [[ "$SKIP_PROCESS_DETECTION" == "true" ]]; then
+	IS_RUNNING="true"
+else
+	# Note: In this case, `$USER_FILTER` must not have quotes around it.
+	# shellcheck disable=SC2086
+	IS_RUNNING=$(pgrep $USER_FILTER -o -a -f "$PROCESS" --ignore-ancestors)
+fi
 
 if [[ -n "$IS_RUNNING" ]]; then
 	# trying for XDG_CONFIG_HOME first.
@@ -301,6 +314,13 @@ if [[ -n "$IS_RUNNING" ]]; then
 	# Stop using same path
 	dbus_kwin "$SCRIPT_PATH" ${SCRIPT_API_PATH}.stop >/dev/null 2>&1
 
+	if [[ "$SKIP_PROCESS_DETECTION" == "true" ]]; then
+		count=$(journalctl --user --identifier=kwin_wayland --grep=$RESULT_ID --since="1 minutes ago" | sed 's/.*: result=//')
+		echo "count: '$count'"
+		if [[ "$count" -eq 0 ]]; then
+			$COMMAND &
+		fi
+	fi
 elif [[ -n "$COMMAND" ]]; then
 	$COMMAND &
 fi


### PR DESCRIPTION
Added new option `--skip-process-detection` that will start a new instance of no running window was found, fixes #23.

I also added a new option `--query`:

`start window query mode. you need to click a window, informations about it will be shown in the terminal. you can find the window class as "resourceClass"`
